### PR TITLE
Fix the main entry file to index.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ob-appsync-events-request",
   "version": "0.0.6",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "scripts": {
     "build": "npx tsc --emitDeclarationOnly && node scripts/build.mjs",


### PR DESCRIPTION
When using the package in Jest environment, we are met with an error of the import.

This is caused by the mismatch between the build script and the main entry point in package.json

This PR aims to correct this by changing the path to built file to be correctly set at `index.cjs` instead of `index.js`

This also solves the opened issue: https://github.com/onlybakam/ob-appsync-events-request/issues/1